### PR TITLE
fix(user.handler.ts): change return of api/user to {id, email}

### DIFF
--- a/src/dtos/out/user/user.dto.ts
+++ b/src/dtos/out/user/user.dto.ts
@@ -3,7 +3,7 @@ import { Static, Type } from '@sinclair/typebox';
 
 export const UserDto = Type.Object({
     id: ObjectId,
-    userName: Type.String({ format: 'userName' })
+    email: Type.String({ format: 'email' })
 });
 
 export type UserDto = Static<typeof UserDto>;

--- a/src/handlers/user.handler.ts
+++ b/src/handlers/user.handler.ts
@@ -8,7 +8,7 @@ const getUserById: Handler<UserDto> = async (req, res) => {
     const user = await prisma.user.findUnique({
         select: {
             id: true,
-            userName: true
+            email: true
         },
         where: { id: userId }
     });


### PR DESCRIPTION
The older version return {id, username}. But after integrate google oauth, some user may don't have username and is identify by their email, so return {id, email} for better semantically accurate representation.