### PR TITLE
feat(edit pdf): change select page custom from array to comma-separated string

### DIFF
--- a/src/dtos/in/uploadFile.dto .ts
+++ b/src/dtos/in/uploadFile.dto .ts
@@ -23,7 +23,7 @@ export const UploadConfigParamsDto = Type.Object({
 export const UploadConfigBodyDto = Type.Object({
     numOfCopies: Type.Number(),
     layout: Type.Union([Type.Literal('portrait'), Type.Literal('landscape')]),
-    pages: Type.Union([Type.Literal('all'), Type.Literal('odd'), Type.Literal('even'), Type.Array(Type.String())]),
+    pages: Type.Union([Type.Literal('all'), Type.Literal('odd'), Type.Literal('even'), Type.String()]),
     pagesPerSheet: Type.Union([
         Type.Literal('1'),
         Type.Literal('2'),

--- a/src/handlers/printingRequest.handler.ts
+++ b/src/handlers/printingRequest.handler.ts
@@ -155,7 +155,7 @@ const handleUploadingFile = async (printingRequestId: string, file: Buffer, file
     try {
         const fileInformation = await prisma.$transaction(async () => {
             const fileExtension = fileName.split('.').pop();
-            const numPage = fileExtension === 'pdf' ? await getNumpages(file) : 1;
+            const numPage = fileExtension === 'pdf' ? await getNumPages(file) : 1;
 
             const fileMetadata = {
                 fileName: fileName,
@@ -236,7 +236,7 @@ const handleUploadingConfig = async (fileId: string, config: UploadConfigBodyDto
  * @returns {Promise<number>} The number of pages in the PDF file.
  * @throws {Error} If an error occurs while parsing the PDF or if the file is not a valid PDF.
  */
-const getNumpages = async (file: Buffer) => {
+const getNumPages = async (file: Buffer) => {
     try {
         const data = await pdf(file);
         return data.numpages;
@@ -297,7 +297,7 @@ const uploadFileToPrintingRequest: Handler<
 
         return res.status(200).send(fileInformation);
     } catch (err) {
-        logger.error('???????');
+        logger.error('Error when uploading file to printing request');
         res.badRequest(err.message);
     }
 };

--- a/src/types/printing.d.ts
+++ b/src/types/printing.d.ts
@@ -1,6 +1,6 @@
 type PageSide = 'one' | 'both';
 type EdgeBinding = 'long' | 'short';
 type PageSideEdge = 'one' | EdgeBinding;
-type KeepPages = 'all' | 'odd' | 'even' | string[];
+type KeepPages = 'all' | 'odd' | 'even' | string;
 type Orientation = 'portrait' | 'landscape';
 type PagePerSheet = 1 | 2 | 4 | 6 | 9 | 16;


### PR DESCRIPTION
This feature involves changing the representation of selected custom pages from an array to a
comma-separated string. Additionally, a bug related to the value of the order embedded in the page
has been fixed.