### PR TITLE
fix(permission): change permission of get configuration APIs to be accessible by all roles

### DIFF
--- a/src/routes/apis/configuration.plugin.ts
+++ b/src/routes/apis/configuration.plugin.ts
@@ -8,7 +8,7 @@ export const configurationPlugin = createRoutes('Configuration', [
     {
         method: 'GET',
         url: '/',
-        roles: [USER_ROLES.admin],
+        roles: ['*'],
         schema: {
             summary: 'Get list configurations',
             description: 'Get all current name and value of configurations',
@@ -21,7 +21,7 @@ export const configurationPlugin = createRoutes('Configuration', [
     {
         method: 'GET',
         url: '/acceptedExtension',
-        roles: [USER_ROLES.admin],
+        roles: ['*'],
         schema: {
             summary: 'Get list accepted extensions',
             description: 'Get all current accepted extensions of printing file',


### PR DESCRIPTION
This bug fix involves changing the permission settings of the get configuration APIs to make them
accessible by all roles. This change applies to the get all and acceptedExtension APIs.