### PR TITLE
fix(execute printing request): decrease appropriate user's remain coi…

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -76,7 +76,7 @@ const createStudent = async () => {
     const students: Student[] = studentUser.map((user) => {
         return {
             default_coin_per_sem: 100,
-            remain_coin: 50,
+            remain_coin: 5000,
             id: user.id
         };
     });

--- a/src/handlers/printingRequest.handler.ts
+++ b/src/handlers/printingRequest.handler.ts
@@ -331,6 +331,7 @@ const uploadConfigToPrintingRequest: Handler<UploadConfigResultDto, { Params: Up
     res
 ) => {
     try {
+        //TODO: update correct coin
         const fileConfig = req.body;
         if (!fileConfig) {
             return res.badRequest('Missing config data');
@@ -377,8 +378,37 @@ const getFilesOfPrintingRequest = async (printingRequestId: string) => {
 
 const executePrintingRequest: Handler<PrintingFileResultDto, { Body: PrintingRequestInputDto }> = async (req, res) => {
     try {
-        const filesOfPrintingRequest = await getFilesOfPrintingRequest(req.body.printingRequestId);
+        //TODO: roles is undefined
+        // if (!req.roles || !req.roles.includes(USER_ROLES.student)) {
+        //     return res.badRequest('This endpoint is only accessible to students.');
+        // }
 
+        const userId = req.userId;
+        const printingRequestId = req.body.printingRequestId;
+
+        const [printingRequest, student] = await Promise.all([
+            prisma.printingRequest.findFirst({ where: { id: printingRequestId }, select: { coins: true } }),
+            prisma.student.findFirst({ where: { id: userId }, select: { remain_coin: true } })
+        ]);
+
+        if (!printingRequest) {
+            return res.badRequest('Invalid printing request id');
+        }
+
+        if (!student) {
+            logger.warn('The logic of the system is incorrect; this user cannot execute the printing request');
+            return res.badRequest('This endpoint is only accessible to students.');
+        }
+
+        const requireCoins = printingRequest.coins;
+
+        if (requireCoins > student.remain_coin) {
+            return res.badRequest("User doesn't have enough coins to execute the printing request");
+        }
+
+        await prisma.student.update({ where: { id: userId }, data: { remain_coin: { decrement: requireCoins } } });
+
+        const filesOfPrintingRequest = await getFilesOfPrintingRequest(printingRequestId);
         filesOfPrintingRequest.forEach(async (file) => {
             const buffer = await minio.getFileFromMinio(file.minioName);
             const config = await getConfigOfFile(file.minioName);

--- a/src/hooks/auth/checkRole.ts
+++ b/src/hooks/auth/checkRole.ts
@@ -1,13 +1,16 @@
 import { envs } from '@configs';
-import { PERMISSION_DENIED } from '@constants';
-import jwt, { JwtPayload } from 'jsonwebtoken';
+import { MUST_LOGIN_FIRST, PERMISSION_DENIED } from '@constants';
+import jwt from 'jsonwebtoken';
 import { RolesValidation } from 'src/types/auth';
 
 export const checkRoles: RolesValidation = (allowedRoles) => (req, res, done) => {
     const token = req.cookies.token;
+    if (!token) return res.unauthorized(MUST_LOGIN_FIRST);
     try {
-        const decodedPayload = jwt.verify(token || '', envs.JWT_SECRET) as JwtPayload;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const decodedPayload: any = jwt.verify(token, envs.JWT_SECRET);
         req.roles = decodedPayload['roles'];
+
         const result = req.roles.map((role) => allowedRoles.includes(role)).find((val) => val === true);
         if (!result) return res.forbidden(PERMISSION_DENIED);
         done();

--- a/src/interfaces/handler.ts
+++ b/src/interfaces/handler.ts
@@ -1,6 +1,7 @@
 import { FastifyRequest, FastifyReply, RouteGenericInterface } from 'fastify';
+import { UserRole } from 'src/types/auth';
 
 export type Handler<RS = unknown, RQ extends RouteGenericInterface = Record<string, never>> = (
-    req: FastifyRequest<RQ> & { userId: string },
+    req: FastifyRequest<RQ> & { userId: string } & { roles: UserRole[] },
     res: FastifyReply
 ) => Result<RS>;


### PR DESCRIPTION
…ns base on printing request

This bug fix involves decreasing the appropriate coins of a printing request when executing it. Additionally, executing a printing request is now restricted to students only, resulting in a breaking change.

BREAKING CHANGE: executing a printing request is now restricted to students only