### PR TITLE
feat(coin): implement new handler and API for coin to VND configuration

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -94,6 +94,10 @@ jobs:
             echo MINIO_BUCKET_NAME=${{ secrets.MINIO_BUCKET_NAME }} >> .env
             echo >> .env   
 
+            echo OPEN_EXCHANGE_RATES_ENDPOINT=${{ vars.OPEN_EXCHANGE_RATES_ENDPOINT }} >> .env
+            echo OPEN_EXCHANGE_RATES_APP_ID=${{ secrets.OPEN_EXCHANGE_RATES_APP_ID }} >> .env
+            echo >> .env
+
             echo CHECKOUT_ENVIRONMENT=${{ vars.CHECKOUT_ENVIRONMENT }} >> .env
             echo PAYPAL_LIVE_ENDPOINT=${{ vars.PAYPAL_LIVE_ENDPOINT }} >> .env
             echo PAYPAL_SANDBOX_ENDPOINT=${{ vars.PAYPAL_SANDBOX_ENDPOINT }} >> .env

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -105,7 +105,6 @@ jobs:
 
             echo OPEN_EXCHANGE_RATES_ENDPOINT=${{ vars.OPEN_EXCHANGE_RATES_ENDPOINT }} >> .env
             echo OPEN_EXCHANGE_RATES_APP_ID=${{ secrets.OPEN_EXCHANGE_RATES_APP_ID }} >> .env
-            
             echo >> .env
 
             echo GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }} >> .env

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -211,6 +211,7 @@ const createConfiguration = async () => {
     }[] = [
         { name: 'coin per page', value: '2', description: 'The amount of coin a student needs to print one page' },
         { name: 'dollar to coin', value: '73', description: 'The amount of coin user gets per dollar' },
+        { name: 'coin to vnd', value: '200', description: 'The value of one coin exchange to vnd' },
         { name: 'coin per sem', value: '100', description: 'The amount of coin a student has free in one semester' },
         ///100mb = 100 * 1024 * 1024 (byte)
         { name: 'max file size', value: `${100 * 1024 * 1024}`, description: 'The amount of coin a student has free in one semester' },

--- a/src/constants/coin.ts
+++ b/src/constants/coin.ts
@@ -1,1 +1,2 @@
 export const DEFAULT_DOLLAR_TO_COIN = 73;
+export const DEFAULT_COIN_TO_VND = 200;

--- a/src/dtos/out/configuration/acceptedExtension.dto.ts
+++ b/src/dtos/out/configuration/acceptedExtension.dto.ts
@@ -5,6 +5,7 @@ export const ServiceFeeDto = Type.Number();
 export const CoinPerPageDto = Type.Number();
 export const CoinPerSemDto = Type.Number();
 export const DollarToCoinDto = Type.Number();
+export const CoinToVNDDto = Type.Number();
 export const MaxFileSizeDto = Type.Number();
 
 export type AcceptedExtensionDto = Static<typeof AcceptedExtensionDto>;
@@ -12,4 +13,5 @@ export type ServiceFeeDto = Static<typeof ServiceFeeDto>;
 export type CoinPerPageDto = Static<typeof CoinPerPageDto>;
 export type CoinPerSemDto = Static<typeof CoinPerSemDto>;
 export type DollarToCoinDto = Static<typeof DollarToCoinDto>;
+export type CoinToVNDDto = Static<typeof CoinToVNDDto>;
 export type MaxFileSizeDto = Static<typeof MaxFileSizeDto>;

--- a/src/handlers/configuration.handler.ts
+++ b/src/handlers/configuration.handler.ts
@@ -57,6 +57,7 @@ const getCoinPerSem: Handler<CoinPerSemDto> = async () => {
         throw err;
     }
 };
+
 const getDollarToCoin: Handler<DollarToCoinDto> = async () => {
     try {
         return await DBConfiguration.dollarToCoin();
@@ -65,6 +66,16 @@ const getDollarToCoin: Handler<DollarToCoinDto> = async () => {
         throw err;
     }
 };
+
+const getCoinToVnd: Handler<DollarToCoinDto> = async () => {
+    try {
+        return await DBConfiguration.coinToVnd();
+    } catch (err) {
+        logger.error('Error when getting coin to VND ratio configuration:', err);
+        throw err;
+    }
+};
+
 const getMaxFileSizeDto: Handler<MaxFileSizeDto> = async () => {
     try {
         return await DBConfiguration.maxFileSize();
@@ -106,5 +117,6 @@ export const configurationHandler = {
     getCoinPerPage,
     getCoinPerSem,
     getDollarToCoin,
+    getCoinToVnd,
     getMaxFileSizeDto
 };

--- a/src/handlers/getConfigurationInDb.handler.ts
+++ b/src/handlers/getConfigurationInDb.handler.ts
@@ -4,6 +4,7 @@ import {
     DEFAULT_ACCEPTED_EXTENSION,
     DEFAULT_COIN_PER_PAGE,
     DEFAULT_COIN_PER_SEM,
+    DEFAULT_COIN_TO_VND,
     DEFAULT_DOLLAR_TO_COIN,
     DEFAULT_MAX_FILE_SIZE,
     DEFAULT_SERVICE_FEE
@@ -112,6 +113,24 @@ const dollarToCoin: () => Promise<number> = async () => {
     }
 };
 
+const coinToVnd: () => Promise<number> = async () => {
+    try {
+        const coinToVndConfiguration = await prisma.configuration.findMany({
+            select: { value: true },
+            where: { name: 'coin to vnd' }
+        });
+        if (coinToVndConfiguration.length === 0) {
+            logger.warn(`No "coin to vnd" configuration found. Using default value: ${DEFAULT_COIN_TO_VND}.`);
+            return DEFAULT_DOLLAR_TO_COIN;
+        }
+        const coinPerSem = Number(coinToVndConfiguration[0]?.value);
+
+        return coinPerSem;
+    } catch (error) {
+        throw new Error('Failed to retrieve "coin to vnd" configuration:', error);
+    }
+};
+
 const maxFileSize: () => Promise<number> = async () => {
     try {
         const maxFileSizeConfiguration = await prisma.configuration.findMany({
@@ -144,8 +163,8 @@ const serviceFee: () => Promise<number> = async () => {
 
         return coinPerSem;
     } catch (error) {
-        throw new Error('Failed to retrieve "max file size" configuration:', error);
+        throw new Error('Failed to retrieve "service fee" configuration:', error);
     }
 };
 
-export const DBConfiguration = { acceptedExtensions, coinPerPage, coinPerSem, dollarToCoin, getAll, maxFileSize, serviceFee };
+export const DBConfiguration = { acceptedExtensions, coinPerPage, coinPerSem, dollarToCoin, coinToVnd, getAll, maxFileSize, serviceFee };

--- a/src/routes/apis/configuration.plugin.ts
+++ b/src/routes/apis/configuration.plugin.ts
@@ -4,6 +4,7 @@ import {
     AcceptedExtensionDto,
     CoinPerPageDto,
     CoinPerSemDto,
+    CoinToVNDDto,
     ConfigurationDto,
     DollarToCoinDto,
     MaxFileSizeDto,
@@ -87,9 +88,23 @@ export const configurationPlugin = createRoutes('Configuration', [
             description: '',
             response: {
                 200: DollarToCoinDto
-            }
+            },
+            deprecated: true
         },
         handler: configurationHandler.getDollarToCoin
+    },
+    {
+        method: 'GET',
+        url: '/coinToVnd',
+        roles: ['*'],
+        schema: {
+            summary: '',
+            description: '',
+            response: {
+                200: CoinToVNDDto
+            }
+        },
+        handler: configurationHandler.getCoinToVnd
     },
     {
         method: 'GET',


### PR DESCRIPTION
This feature includes the implementation of a new handler and API for configuring the conversion
rate from coin to VND. Additionally, the missing environment variables for the Open Exchange Rate
endpoint and app ID have been added in the dev-deploy CD. The 'get dollarToCoin' API has been set to
deprecated.