### PR TITLE
refactor(paypal): change amount of create PayPal Order to VND; use VND as immediate unit of coin

### DIFF
--- a/src/routes/apis/checkout.plugin.ts
+++ b/src/routes/apis/checkout.plugin.ts
@@ -23,6 +23,8 @@ export const coinPlugin = createRoutes('Buy coin', [
         roles: ['*'],
         schema: {
             summary: 'Create PayPal Order to buy more coin',
+            description:
+                'Create PayPal Order to buy more coin, the unit of amount is vnd, the system will convert to apporiate currency base on amount vnd',
             body: CreatePayPalOrderDto,
             response: {
                 200: PaypalDto

--- a/src/utils/CurrencyConvert.ts
+++ b/src/utils/CurrencyConvert.ts
@@ -15,3 +15,18 @@ export async function convertVNDtoUSD(amountInVND: number): Promise<number> {
         throw new Error('An error occurred while processing the conversion');
     }
 }
+
+export async function convertUSDtoVND(amountInUSD: number): Promise<number> {
+    const targetCurrency = 'USD';
+
+    try {
+        const currencyExchangeRates = await currencyExchangeRateService.getVietNameseExchangeRate(envs.OPEN_EXCHANGE_RATES_APP_ID);
+
+        const exchangeRate = currencyExchangeRates.rates[targetCurrency];
+        const amountInVND = (amountInUSD / Number(exchangeRate)) * 1.0;
+        return amountInVND;
+    } catch (error) {
+        console.error(`Error: ${error.message}`);
+        throw new Error('An error occurred while processing the conversion');
+    }
+}


### PR DESCRIPTION
This refactor involves changing the amount in the create PayPal Order API from USD to VND.
Additionally, it uses VND as the immediate unit of coin instead of USD. A simple USD to VND utility
function based on the original VND to USD function has also been implemented. This change includes a
breaking change as it switches the immediate unit of coin to VND.

BREAKING CHANGE: Switches the immediate unit of coin from USD to VND