### PR TITLE
fix(coin): round VND conversion from USD to avoid missing bonus coin

### DIFF
--- a/src/handlers/coin.handler.ts
+++ b/src/handlers/coin.handler.ts
@@ -75,7 +75,11 @@ const completePayPalOrder: Handler<CompletePaypalDto, { Body: CompletePayPalOrde
             completeOrderResponse.purchase_units ? completeOrderResponse.purchase_units[0].payments.captures[0].amount.value : 0
         );
 
-        const amountVND = await convertUSDtoVND(amountUSD);
+        logger.error(amountUSD);
+
+        const amountVND = Math.round(await convertUSDtoVND(amountUSD));
+
+        logger.error(amountVND);
 
         const totalCoin = await calculateTotalCoins(amountVND);
 


### PR DESCRIPTION
The fix addresses a scenario where the conversion from USD to VND in the completion of a PayPal order might result in a fractional VND value due to the infinite float of the exchange ratio. Rounding the VND result prevents the loss of bonus coins.